### PR TITLE
Fix flood fill result return

### DIFF
--- a/arc-prize.py
+++ b/arc-prize.py
@@ -28,6 +28,7 @@ def flood_fill_border_zero_to_two(grid):
                     q.append((nr, nc))
                     visited[nr][nc] = True
 
+    return result
 input_grid = [
     [0, 0, 0, 0, 0],
     [0, 0, 1, 0, 0],


### PR DESCRIPTION
## Summary
- ensure `flood_fill_border_zero_to_two` returns the filled grid

## Testing
- `python3 arc-prize.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6851fdccb29c8332bb540d8ee89f7510